### PR TITLE
Fix the toArray function to start the array at the root node xml

### DIFF
--- a/src/XmlNode.php
+++ b/src/XmlNode.php
@@ -263,7 +263,9 @@ class XmlNode
 
     public function toArray(Closure $func = null): array
     {
-        return $this->_toArray($this->DOMNode(), $func);
+        $sxml = simplexml_import_dom($this->DOMNode());
+
+        return [$sxml->getName() => $this->_toArray($sxml, $func)];
     }
 
     protected function _toArray(SimpleXMLElement|DOMNode|array $arr, Closure|null $func): array

--- a/src/XmlNode.php
+++ b/src/XmlNode.php
@@ -269,37 +269,41 @@ class XmlNode
 
     protected function _toArray(SimpleXMLElement $node): array|string
     {
+        $hasAttributes = (count($node->attributes()) > 0);
+        $hasChildren = (count($node->children()) > 0);
+        $textValue = trim((string)$node);
+        $hasText = (strlen($textValue) > 0);
+
+        if (!$hasAttributes && !$hasChildren) {
+            return $textValue;
+        }
+
         $output = [];
 
-        foreach ($node->attributes() as $attrName => $attrValue) {
-            $output['@attributes'][$attrName] = (string)$attrValue;
+        if ($hasAttributes) {
+            foreach ($node->attributes() as $attrName => $attrValue) {
+                $output['@attributes'][$attrName] = (string)$attrValue;
+            }
         }
 
-        foreach ($node->children() as $child) {
-            $childName = $child->getName();
-            $childData = $this->_toArray($child);
+        if ($hasChildren) {
+            foreach ($node->children() as $child) {
+                $childName = $child->getName();
+                $childData = $this->_toArray($child);
 
-            if (isset($output[$childName])) {
-                if (!is_array($output[$childName]) || !isset($output[$childName][0])) {
-                    $output[$childName] = [$output[$childName]];
+                if (isset($output[$childName])) {
+                    if (!is_array($output[$childName]) || !isset($output[$childName][0])) {
+                        $output[$childName] = [$output[$childName]];
+                    }
+                    $output[$childName][] = $childData;
+                } else {
+                    $output[$childName] = $childData;
                 }
-                $output[$childName][] = $childData;
-            } else {
-                $output[$childName] = $childData;
             }
         }
 
-        $text = trim((string)$node);
-        if (strlen($text) > 0) {
-            if (!empty($output)) {
-                $output['@value'] = $text;
-            } else {
-                $output = $text;
-            }
-        }
-
-        if (is_array($output) && empty($output)) {
-            return '';
+        if ($hasText) {
+            $output['@value'] = $textValue;
         }
 
         return $output;

--- a/src/XmlNode.php
+++ b/src/XmlNode.php
@@ -264,35 +264,45 @@ class XmlNode
     public function toArray(Closure $func = null): array
     {
         $sxml = simplexml_import_dom($this->DOMNode());
-
-        return [$sxml->getName() => $this->_toArray($sxml, $func)];
+        return [$sxml->getName() => $this->_toArray($sxml)];
     }
 
-    protected function _toArray(SimpleXMLElement|DOMNode|array $arr, Closure|null $func): array
+    protected function _toArray(SimpleXMLElement $node): array|string
     {
-        if ($arr instanceof SimpleXMLElement) {
-            return $this->_toArray((array) $arr, $func);
+        $output = [];
+
+        foreach ($node->attributes() as $attrName => $attrValue) {
+            $output['@attributes'][$attrName] = (string)$attrValue;
         }
 
-        if ($arr instanceof DOMNode) {
-            return $this->_toArray((array) simplexml_import_dom($arr), $func);
-        }
+        foreach ($node->children() as $child) {
+            $childName = $child->getName();
+            $childData = $this->_toArray($child);
 
-        $newArr = array();
-        if (!empty($arr)) {
-            foreach ($arr as $key => $value) {
-                $newArr[$key] =
-                    (
-                    is_array($value)
-                    || ($value instanceof DOMNode)
-                    || ($value instanceof SimpleXMLElement)
-                        ? $this->_toArray($value, $func)
-                        : (!empty($func) ? $func($value) : $value)
-                    );
+            if (isset($output[$childName])) {
+                if (!is_array($output[$childName]) || !isset($output[$childName][0])) {
+                    $output[$childName] = [$output[$childName]];
+                }
+                $output[$childName][] = $childData;
+            } else {
+                $output[$childName] = $childData;
             }
         }
 
-        return $newArr;
+        $text = trim((string)$node);
+        if (strlen($text) > 0) {
+            if (!empty($output)) {
+                $output['@value'] = $text;
+            } else {
+                $output = $text;
+            }
+        }
+
+        if (is_array($output) && empty($output)) {
+            return '';
+        }
+
+        return $output;
     }
 
     /**

--- a/tests/XmlUtilTest.php
+++ b/tests/XmlUtilTest.php
@@ -352,6 +352,29 @@ class XmlUtilTest extends TestCase
         $this->assertEquals($expected, $array);
     }
 
+    public function testXmlToArrayWithMixedContent(): void
+    {
+        $xmlString = '<root><node param="pval">value<other>value</other><node2 a="2"></node2></node></root>';
+        $xml = new XmlDocument($xmlString);
+        $array = $xml->toArray();
+
+        $expected = [
+            'root' => [
+                'node' => [
+                    '@attributes' => ['param' => 'pval'],
+                    '@value' => 'value',
+                    'other' => 'value',
+                    'node2' => [
+                        '@attributes' => ['a' => '2']
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals($expected, $array);
+    }
+
+
     public function testSelectNodesNamespace(): void
     {
         $file = new File(__DIR__ . '/feed-atom.txt');

--- a/tests/XmlUtilTest.php
+++ b/tests/XmlUtilTest.php
@@ -316,7 +316,7 @@ class XmlUtilTest extends TestCase
         $xml = new XmlDocument($file, preserveWhiteSpace: false);
 
         $array = $xml->toArray();
-        $this->assertEquals([ "node" => [ "subnode" => "value"]], $array);
+        $this->assertEquals(['root' => [ "node" => [ "subnode" => "value"]]], $array);
     }
 
     public function testXml2Array2(): void
@@ -324,7 +324,7 @@ class XmlUtilTest extends TestCase
         $xml = new XmlDocument('<root><node param="pval">value</node></root>');
 
         $array = $xml->toArray();
-        $this->assertEquals([ "node" => "value"], $array);
+        $this->assertEquals(['root' => [ "node" => "value"]], $array);
     }
 
     public function testSelectNodesNamespace(): void

--- a/tests/XmlUtilTest.php
+++ b/tests/XmlUtilTest.php
@@ -310,7 +310,7 @@ class XmlUtilTest extends TestCase
 
     }
 
-    public function testXml2Array1(): void
+    public function testXml2Array(): void
     {
         $file = new File(__DIR__ . '/buggy.xml');
         $xml = new XmlDocument($file, preserveWhiteSpace: false);
@@ -319,12 +319,37 @@ class XmlUtilTest extends TestCase
         $this->assertEquals(['root' => [ "node" => [ "subnode" => "value"]]], $array);
     }
 
-    public function testXml2Array2(): void
+    public function testXmlToArrayWithAttributeAndNoText(): void
+    {
+        $xml = new XmlDocument('<root><node param="pval"/></root>');
+        $array = $xml->toArray();
+
+        $expected = [
+            'root' => [
+                'node' => [
+                    '@attributes' => ['param' => 'pval']
+                ]
+            ]
+        ];
+
+        $this->assertEquals($expected, $array);
+    }
+
+    public function testXmlToArrayWithAttributeAndText(): void
     {
         $xml = new XmlDocument('<root><node param="pval">value</node></root>');
-
         $array = $xml->toArray();
-        $this->assertEquals(['root' => [ "node" => "value"]], $array);
+
+        $expected = [
+            'root' => [
+                'node' => [
+                    '@attributes' => ['param' => 'pval'],
+                    '@value' => 'value'
+                ]
+            ]
+        ];
+
+        $this->assertEquals($expected, $array);
     }
 
     public function testSelectNodesNamespace(): void


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the `toArray` function to ensure the resulting array starts with the root node of the XML structure and update related test cases to reflect this change.

### Why are these changes being made?

The previous implementation of the `toArray` function did not include the root node in the resulting array, which could lead to unexpected results when processing XML documents. By including the root node, the array representation becomes more comprehensive and aligns with the structure of the XML document, resulting in more predictable behavior for users of the function.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->