### PR TITLE
Includes the older toArray conversion

### DIFF
--- a/tests/XmlUtilTest.php
+++ b/tests/XmlUtilTest.php
@@ -310,19 +310,36 @@ class XmlUtilTest extends TestCase
 
     }
 
-    public function testXml2Array(): void
+    public function testXml2Array1(): void
     {
         $file = new File(__DIR__ . '/buggy.xml');
         $xml = new XmlDocument($file, preserveWhiteSpace: false);
 
         $array = $xml->toArray();
+        $this->assertEquals([ "node" => [ "subnode" => "value"]], $array);
+    }
+
+    public function testXml2Array2(): void
+    {
+        $xml = new XmlDocument('<root><node param="pval">value</node></root>');
+
+        $array = $xml->toArray();
+        $this->assertEquals([ "node" => "value"], $array);
+    }
+
+    public function testXml2FullArray(): void
+    {
+        $file = new File(__DIR__ . '/buggy.xml');
+        $xml = new XmlDocument($file, preserveWhiteSpace: false);
+
+        $array = $xml->toFullArray();
         $this->assertEquals(['root' => [ "node" => [ "subnode" => "value"]]], $array);
     }
 
     public function testXmlToArrayWithAttributeAndNoText(): void
     {
         $xml = new XmlDocument('<root><node param="pval"/></root>');
-        $array = $xml->toArray();
+        $array = $xml->toFullArray();
 
         $expected = [
             'root' => [
@@ -338,7 +355,7 @@ class XmlUtilTest extends TestCase
     public function testXmlToArrayWithAttributeAndText(): void
     {
         $xml = new XmlDocument('<root><node param="pval">value</node></root>');
-        $array = $xml->toArray();
+        $array = $xml->toFullArray();
 
         $expected = [
             'root' => [
@@ -356,7 +373,7 @@ class XmlUtilTest extends TestCase
     {
         $xmlString = '<root><node param="pval">value<other>value</other><node2 a="2"></node2></node></root>';
         $xml = new XmlDocument($xmlString);
-        $array = $xml->toArray();
+        $array = $xml->toFullArray();
 
         $expected = [
             'root' => [


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Reintroduce the original `toArray` method while retaining the `toFullArray` method, allowing XML nodes to be converted to arrays with and without fully recursive details, and update related test cases accordingly.

### Why are these changes being made?
Previously, the recursion depth of the array conversion was fixed with the `toFullArray` method, but a simpler option for array conversion without complete depth is necessary for scenarios where details like attributes aren't required, hence bringing back the `toArray` method. This provides flexibility for different use cases while maintaining the existing functionality. Test cases are updated to validate both the methods separately for consistent functionality verification.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->